### PR TITLE
Fix unwanted line below home button

### DIFF
--- a/src/app/components/navbar/navbar.css
+++ b/src/app/components/navbar/navbar.css
@@ -83,5 +83,6 @@
       border-radius: 50px;
       cursor: pointer;
       transition: background 0.2s, transform 0.15s;
+      text-decoration: none;
     }
-    .nav-cta:hover { background: var(--fern); transform: translateY(-1px); }
+    .nav-cta:hover { background: var(--fern); transform: translateY(-1px);}


### PR DESCRIPTION
Fixed the unwanted line appearing below the Home button by removing the default text decoration styling from the nav-cta anchor element in navbar.css.
Fixes #37 