### PR TITLE
Fix navbar compilation errors preventing project startup

### DIFF
--- a/src/app/components/navbar/navbar.css
+++ b/src/app/components/navbar/navbar.css
@@ -208,7 +208,7 @@ nav {
   }
   
 }
-=======
+
     :root {
       --forest:    #1E3A1A;
       --moss:      #2D5A27;

--- a/src/app/components/navbar/navbar.ts
+++ b/src/app/components/navbar/navbar.ts
@@ -14,6 +14,10 @@ export class NavbarComponent implements OnInit {
   isScrolled = false;
   menuOpen = false;
 
+  ngOnInit(): void {
+    // Initialization logic can go here
+  }
+
   toggleMenu() {
     this.menuOpen = !this.menuOpen;
   }


### PR DESCRIPTION
This PR fixes compilation errors that prevent the Angular application from starting after a fresh clone.

### Changes Made

- Removed leftover merge conflict marker (`=======`) from `navbar.css`
- Added missing `ngOnInit()` implementation in `NavbarComponent`

### Verification

1. Clone repository
2. Run `npm install`
3. Run `ng serve`

The application now compiles and runs successfully.

Fixes #114