### PR TITLE
fix: remove broken contact link from footer

### DIFF
--- a/src/app/components/footer/footer.html
+++ b/src/app/components/footer/footer.html
@@ -7,7 +7,7 @@
       <a routerLink="/remedies">Remedies</a>
       <a routerLink="/herbs">Herbs</a>
       <a routerLink="/doshas">Doshas</a>
-      <a routerLink="/contact">Contact</a>
+     
     </div>
   </div>
 


### PR DESCRIPTION
## Description
Removed the broken Contact link from the footer.

## Changes Made
- Removed the footer link pointing to `/contact`
- Verified that all remaining footer links navigate correctly

Fixes #104